### PR TITLE
chore: update tailwindcss-primeui to v0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "posthog-js": "^1.260.1",
     "primevue": "^4.3.7",
     "sitemap": "^8.0.0",
-    "tailwindcss-primeui": "^0.3.4"
+    "tailwindcss-primeui": "^0.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.28.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       tailwindcss-primeui:
-        specifier: ^0.3.4
-        version: 0.3.4(tailwindcss@3.4.17)
+        specifier: ^0.6.1
+        version: 0.6.1(tailwindcss@3.4.17)
     devDependencies:
       '@babel/core':
         specifier: ^7.28.3
@@ -7401,8 +7401,8 @@ packages:
     peerDependencies:
       tailwindcss: 1 || 2 || 2.0.1-compat || 3
 
-  tailwindcss-primeui@0.3.4:
-    resolution: {integrity: sha512-5+Qfoe5Kpq2Iwrd6umBUb3rQH6b7+pL4jxJUId0Su5agUM6TwCyH5Pyl9R0y3QQB3IRuTxBNmeS11B41f+30zw==}
+  tailwindcss-primeui@0.6.1:
+    resolution: {integrity: sha512-T69Rylcrmnt8zy9ik+qZvsLuRIrS9/k6rYJSIgZ1trnbEzGDDQSCIdmfyZknevqiHwpSJHSmQ9XT2C+S/hJY4A==}
     peerDependencies:
       tailwindcss: '>=3.1.0'
 
@@ -17158,7 +17158,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  tailwindcss-primeui@0.3.4(tailwindcss@3.4.17):
+  tailwindcss-primeui@0.6.1(tailwindcss@3.4.17):
     dependencies:
       tailwindcss: 3.4.17
 


### PR DESCRIPTION
- Upgraded `tailwindcss-primeui` to version 0.6.1 in package.json and pnpm-lock.yaml.